### PR TITLE
Add Project Key Separator Preference

### DIFF
--- a/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
+++ b/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
@@ -9,6 +9,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.netbeans.api.project.Project;
 import org.openide.filesystems.FileObject;
+import org.radar.radarlint.settings.ProjectKeySeparatorPreference;
 
 /**
  *
@@ -44,7 +45,7 @@ public class MvnProjectAnalyzer {
         if (groupId == null && model.getParent() != null) {
             groupId = model.getParent().getGroupId();
         }
-        return groupId + ":" + model.getArtifactId();
+        return groupId + new ProjectKeySeparatorPreference().getValue() + model.getArtifactId();
     }
     
 }

--- a/src/main/java/org/radar/radarlint/settings/ProjectKeySeparatorPreference.java
+++ b/src/main/java/org/radar/radarlint/settings/ProjectKeySeparatorPreference.java
@@ -1,0 +1,30 @@
+package org.radar.radarlint.settings;
+
+import org.openide.util.NbPreferences;
+import org.radar.radarlint.SonarLintSaveTask;
+
+/**
+ * Separator to use when building a default project key.
+ *
+ * Default is ':' so that project keys end up as groupId:artifactId, but can be modified as needed.
+ *
+ * @author Aaron Watry
+ */
+public class ProjectKeySeparatorPreference extends AbstractPreferenceAccessor<String>{
+    private static final String DEFAULT_SEPARATOR = ":";
+
+    public ProjectKeySeparatorPreference() {
+        super(NbPreferences.forModule(SonarLintSaveTask.class), "sonarqube.project.key.separator");
+    }
+    
+    @Override
+    public void setValue(String value) {
+        getPreferences().put(getPreferenceKey(), value);
+    }
+
+    @Override
+    public String getValue() {
+        return getPreferences().get(getPreferenceKey(), DEFAULT_SEPARATOR);
+    }
+    
+}

--- a/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.form
+++ b/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.form
@@ -18,14 +18,16 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" max="-2" attributes="0">
-                  <Component id="jLabel2" max="32767" attributes="0"/>
-                  <Component id="jLabel1" pref="63" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="jLabel3" pref="164" max="32767" attributes="0"/>
+                  <Component id="jLabel1" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jLabel2" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="serverAddress" max="32767" attributes="0"/>
-                  <Component id="tokenField" pref="598" max="32767" attributes="0"/>
+                  <Component id="tokenField" pref="497" max="32767" attributes="0"/>
+                  <Component id="projectKeySeparator" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -44,7 +46,12 @@
                   <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="tokenField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="180" max="32767" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="projectKeySeparator" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="133" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -75,6 +82,20 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.tokenField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel3">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.jLabel3.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="projectKeySeparator">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.projectKeySeparator.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.java
+++ b/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.java
@@ -1,7 +1,7 @@
 package org.radar.radarlint.ui;
 
 import java.util.Arrays;
-import org.netbeans.api.keyring.Keyring;
+import org.radar.radarlint.settings.ProjectKeySeparatorPreference;
 import org.radar.radarlint.settings.ServerUrlPreference;
 import org.radar.radarlint.settings.TokenAccesor;
 
@@ -26,6 +26,8 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
         serverAddress = new javax.swing.JTextField();
         jLabel2 = new javax.swing.JLabel();
         tokenField = new javax.swing.JPasswordField();
+        jLabel3 = new javax.swing.JLabel();
+        projectKeySeparator = new javax.swing.JTextField();
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.jLabel1.text")); // NOI18N
 
@@ -35,19 +37,25 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
 
         tokenField.setText(org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.tokenField.text")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel3, org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.jLabel3.text")); // NOI18N
+
+        projectKeySeparator.setText(org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.projectKeySeparator.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 63, Short.MAX_VALUE))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, 164, Short.MAX_VALUE)
+                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(serverAddress)
-                    .addComponent(tokenField, javax.swing.GroupLayout.DEFAULT_SIZE, 598, Short.MAX_VALUE))
+                    .addComponent(tokenField, javax.swing.GroupLayout.DEFAULT_SIZE, 497, Short.MAX_VALUE)
+                    .addComponent(projectKeySeparator))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -61,7 +69,11 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel2)
                     .addComponent(tokenField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(180, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(projectKeySeparator, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel3))
+                .addContainerGap(133, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -74,12 +86,14 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
         }else{
             tokenField.setText(null);
         }
+        projectKeySeparator.setText(new ProjectKeySeparatorPreference().getValue());
     }
 
     protected void store() {
         new ServerUrlPreference().setValue(serverAddress.getText());
         char[] adb = tokenField.getPassword();
         new TokenAccesor().setValue(adb);
+        new ProjectKeySeparatorPreference().setValue(projectKeySeparator.getText());
     }
 
     boolean valid() {
@@ -89,6 +103,8 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel3;
+    private javax.swing.JTextField projectKeySeparator;
     private javax.swing.JTextField serverAddress;
     private javax.swing.JPasswordField tokenField;
     // End of variables declaration//GEN-END:variables

--- a/src/main/resources/org/radar/radarlint/ui/Bundle.properties
+++ b/src/main/resources/org/radar/radarlint/ui/Bundle.properties
@@ -105,3 +105,5 @@ RuleDetailsAction.noIssueAtLocation=No SonarLint issue at caret position
 RuleDialog.description.text=<html>\r\n  <head>\r\n\r\n  </head>\r\n  <body>\r\n    <p style="margin-top: 0">\r\n      \r\n    </p>\r\n  </body>\r\n</html>\r\n
 SonarQubeOptionsPanel.jLabel2.text=Token:
 SonarQubeOptionsPanel.tokenField.text=
+SonarQubeOptionsPanel.jLabel3.text=Project Key Separator:
+SonarQubeOptionsPanel.projectKeySeparator.text=


### PR DESCRIPTION
Allows changing the default project key separator from ":" to something else.