### PR TITLE
Check ancestor projects for project key

### DIFF
--- a/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
+++ b/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
@@ -2,9 +2,14 @@ package org.radar.radarlint;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.netbeans.api.project.Project;
@@ -16,12 +21,12 @@ import org.radar.radarlint.settings.ProjectKeySeparatorPreference;
  * @author Víctor
  */
 public class MvnProjectAnalyzer {
-    
-    public FileObject getPomFileObject(Project project) {
+
+    public FileObject getPomFileObject (Project project) {
         return project.getProjectDirectory().getFileObject("pom.xml");
     }
 
-    public Model createModel(Project project) {
+    public Model createModel (Project project) {
         FileObject pomFile = getPomFileObject(project);
         if (pomFile == null) {
             return null;
@@ -36,16 +41,94 @@ public class MvnProjectAnalyzer {
         }
     }
 
-    public String getProjectKey(Model model) {
-        String projectKey = model.getProperties().getProperty("sonar.projectKey");
+    public String getProjectKey (Model model) {
+        //If the maven model has a sonar project key, use it.
+        //If not, check if the project has an ancestor in the same multi-module maven project that does.
+        //Lastly, if the parent (recursive) doesn't have a project key, just generate a default.
+        String projectKey = extractProjectKey(model);
         if (projectKey != null) {
             return projectKey;
         }
+        projectKey = getProjectKeyFromAncestor(model, true);
+        if (projectKey != null) {
+            return projectKey;
+        }
+        return createDefaultProjectKey(model);
+    }
+
+    private String createDefaultProjectKey (Model model) {
         String groupId = model.getGroupId();
         if (groupId == null && model.getParent() != null) {
             groupId = model.getParent().getGroupId();
         }
-        return groupId + new ProjectKeySeparatorPreference().getValue() + model.getArtifactId();
+        return buildProjectKey(groupId, model.getArtifactId(), new ProjectKeySeparatorPreference().getValue());
     }
-    
+
+    private String buildProjectKey (String groupId, String artifactId, String separator) {
+        return groupId + separator + artifactId;
+    }
+
+    private String extractProjectKey (Model model) {
+        //TODO: Don't just use the model, get the effective project model, with properties evaluated.
+        //Our projects are multi-module maven projects where the top-level parent has a property present, and sometimes
+        //it's actually depending on defined properties passed in via command line (or inheritence).
+        return model.getProperties().getProperty("sonar.projectKey");
+    }
+
+    private String getProjectKeyFromAncestor (Model child, boolean loadPoms) {
+        if (child.getParent() == null) {
+            return null;
+        }
+
+        if (loadPoms) {
+            Model parentModel = getParentModel(child);
+            if (parentModel != null) {
+                String projectKey = extractProjectKey(parentModel);
+                if (projectKey != null) {
+                    return projectKey;
+                }
+                return getProjectKeyFromAncestor(parentModel, loadPoms);
+            }
+        } else {
+            if (child.getParent() != null) {
+                String groupId = child.getParent().getGroupId();
+                String artifactId = child.getParent().getArtifactId();
+                return buildProjectKey(groupId, artifactId, new ProjectKeySeparatorPreference().getValue());
+            }
+        }
+
+        return null;
+    }
+
+    private Model getParentModel (Model child) {
+        Parent parent = child.getParent();
+        if (parent != null) {
+            String parentRelativePomPath = parent.getRelativePath();
+
+            if (parentRelativePomPath != null) {
+                Path childPomPath = Paths.get(child.getPomFile().getPath());
+                Path childPomDir = childPomPath.getParent();
+
+                Path parentPomPath = childPomDir.resolve(parentRelativePomPath);
+                Model parentModel = readModel(parentPomPath);
+                return parentModel;
+            }
+        }
+
+        return null;
+    }
+
+    private Model readModel (Path pomPath) {
+        MavenXpp3Reader mavenreader = new MavenXpp3Reader();
+        File pomFile = pomPath.toFile();
+        try (
+            final InputStream is = Files.newInputStream(pomPath);
+            final Reader reader = new InputStreamReader(is)) {
+            Model model = mavenreader.read(reader);
+            model.setPomFile(new File(pomFile.getPath()));
+            return model;
+        } catch (XmlPullParserException | IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
+++ b/src/main/java/org/radar/radarlint/MvnProjectAnalyzer.java
@@ -9,6 +9,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.netbeans.api.project.Project;
 import org.openide.filesystems.FileObject;
+import org.radar.radarlint.settings.ProjectKeySeparatorPreference;
 
 /**
  *
@@ -44,7 +45,7 @@ public class MvnProjectAnalyzer {
         if (groupId == null && model.getParent() != null) {
             groupId = model.getParent().getGroupId();
         }
-        return groupId + ":" + model.getArtifactId();
+        return groupId + new ProjectKeySeparatorPreference().getValue() + model.getArtifactId();
     }
     
 }

--- a/src/main/java/org/radar/radarlint/settings/ProjectKeySeparatorPreference.java
+++ b/src/main/java/org/radar/radarlint/settings/ProjectKeySeparatorPreference.java
@@ -1,0 +1,30 @@
+package org.radar.radarlint.settings;
+
+import org.openide.util.NbPreferences;
+import org.radar.radarlint.SonarLintSaveTask;
+
+/**
+ * Separator to use when building a default project key.
+ *
+ * Default is ':' so that project keys end up as groupId:artifactId, but can be modified as needed.
+ *
+ * @author Aaron Watry
+ */
+public class ProjectKeySeparatorPreference extends AbstractPreferenceAccessor<String>{
+    private static final String DEFAULT_SEPARATOR = ":";
+
+    public ProjectKeySeparatorPreference() {
+        super(NbPreferences.forModule(SonarLintSaveTask.class), "sonarqube.project.key.separator");
+    }
+    
+    @Override
+    public void setValue(String value) {
+        getPreferences().put(getPreferenceKey(), value);
+    }
+
+    @Override
+    public String getValue() {
+        return getPreferences().get(getPreferenceKey(), DEFAULT_SEPARATOR);
+    }
+    
+}

--- a/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.form
+++ b/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.form
@@ -18,14 +18,16 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" max="-2" attributes="0">
-                  <Component id="jLabel2" max="32767" attributes="0"/>
-                  <Component id="jLabel1" pref="63" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="jLabel3" pref="164" max="32767" attributes="0"/>
+                  <Component id="jLabel1" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jLabel2" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="serverAddress" max="32767" attributes="0"/>
-                  <Component id="tokenField" pref="598" max="32767" attributes="0"/>
+                  <Component id="tokenField" pref="497" max="32767" attributes="0"/>
+                  <Component id="projectKeySeparator" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -44,7 +46,12 @@
                   <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="tokenField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="180" max="32767" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="projectKeySeparator" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="133" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -75,6 +82,20 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.tokenField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel3">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.jLabel3.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="projectKeySeparator">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarQubeOptionsPanel.projectKeySeparator.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.java
+++ b/src/main/java/org/radar/radarlint/ui/SonarQubeOptionsPanel.java
@@ -1,7 +1,7 @@
 package org.radar.radarlint.ui;
 
 import java.util.Arrays;
-import org.netbeans.api.keyring.Keyring;
+import org.radar.radarlint.settings.ProjectKeySeparatorPreference;
 import org.radar.radarlint.settings.ServerUrlPreference;
 import org.radar.radarlint.settings.TokenAccesor;
 
@@ -26,6 +26,8 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
         serverAddress = new javax.swing.JTextField();
         jLabel2 = new javax.swing.JLabel();
         tokenField = new javax.swing.JPasswordField();
+        jLabel3 = new javax.swing.JLabel();
+        projectKeySeparator = new javax.swing.JTextField();
 
         org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.jLabel1.text")); // NOI18N
 
@@ -35,19 +37,25 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
 
         tokenField.setText(org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.tokenField.text")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel3, org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.jLabel3.text")); // NOI18N
+
+        projectKeySeparator.setText(org.openide.util.NbBundle.getMessage(SonarQubeOptionsPanel.class, "SonarQubeOptionsPanel.projectKeySeparator.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
-                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 63, Short.MAX_VALUE))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, 164, Short.MAX_VALUE)
+                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(serverAddress)
-                    .addComponent(tokenField, javax.swing.GroupLayout.DEFAULT_SIZE, 598, Short.MAX_VALUE))
+                    .addComponent(tokenField, javax.swing.GroupLayout.DEFAULT_SIZE, 497, Short.MAX_VALUE)
+                    .addComponent(projectKeySeparator))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -61,7 +69,11 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel2)
                     .addComponent(tokenField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(180, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(projectKeySeparator, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel3))
+                .addContainerGap(133, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -74,12 +86,14 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
         }else{
             tokenField.setText(null);
         }
+        projectKeySeparator.setText(new ProjectKeySeparatorPreference().getValue());
     }
 
     protected void store() {
         new ServerUrlPreference().setValue(serverAddress.getText());
         char[] adb = tokenField.getPassword();
         new TokenAccesor().setValue(adb);
+        new ProjectKeySeparatorPreference().setValue(projectKeySeparator.getText());
     }
 
     boolean valid() {
@@ -89,6 +103,8 @@ public final class SonarQubeOptionsPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel3;
+    private javax.swing.JTextField projectKeySeparator;
     private javax.swing.JTextField serverAddress;
     private javax.swing.JPasswordField tokenField;
     // End of variables declaration//GEN-END:variables

--- a/src/main/resources/org/radar/radarlint/ui/Bundle.properties
+++ b/src/main/resources/org/radar/radarlint/ui/Bundle.properties
@@ -105,3 +105,5 @@ RuleDetailsAction.noIssueAtLocation=No SonarLint issue at caret position
 RuleDialog.description.text=<html>\r\n  <head>\r\n\r\n  </head>\r\n  <body>\r\n    <p style="margin-top: 0">\r\n      \r\n    </p>\r\n  </body>\r\n</html>\r\n
 SonarQubeOptionsPanel.jLabel2.text=Token:
 SonarQubeOptionsPanel.tokenField.text=
+SonarQubeOptionsPanel.jLabel3.text=Project Key Separator:
+SonarQubeOptionsPanel.projectKeySeparator.text=


### PR DESCRIPTION
Multi-module maven projects might define a project key at the top-level which is used for all modules.

This MR allows the MvnProjectAnalyzer to inspect the parent project's pom for a project key (recursively).

Currently only works for multi-module maven projects which are part of the same repository. A future enhancement would be to download/calculate the effective pom for the maven project so that property inheritance actually works (my employer actually uses this along with some interpolated property variables... which is another thing that the effective model would help with).