### PR TITLE
Add project key override preference

### DIFF
--- a/src/main/java/org/radar/radarlint/settings/ProjectKeyOverridePreference.java
+++ b/src/main/java/org/radar/radarlint/settings/ProjectKeyOverridePreference.java
@@ -1,0 +1,26 @@
+package org.radar.radarlint.settings;
+
+import java.util.prefs.Preferences;
+
+/**
+ * Allows setting project key override in Netbeans project preferences.
+ *
+ * @author Aaron Watry
+ */
+public class ProjectKeyOverridePreference extends AbstractPreferenceAccessor<String> {
+
+    public ProjectKeyOverridePreference(Preferences preferences) {
+        super(preferences, "sonarLint.project.key.override");
+    }
+
+    @Override
+    public void setValue(String value) {
+        getPreferences().put(getPreferenceKey(), value);
+    }
+
+    @Override
+    public String getValue() {
+        return getPreferences().get(getPreferenceKey(), null);
+    }
+
+}

--- a/src/main/java/org/radar/radarlint/ui/SonarLintCustomizerTab.java
+++ b/src/main/java/org/radar/radarlint/ui/SonarLintCustomizerTab.java
@@ -7,7 +7,6 @@ import javax.swing.JComponent;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.spi.project.ui.support.ProjectCustomizer;
-import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.windows.WindowManager;
 import org.radar.radarlint.EditorAnnotator;
@@ -15,6 +14,7 @@ import org.radar.radarlint.FileOpenedNotifier;
 import org.radar.radarlint.settings.ExcludedFilePatterns;
 import org.radar.radarlint.settings.SonarLintActivePreference;
 import org.radar.radarlint.SonarLintScanner;
+import org.radar.radarlint.settings.ProjectKeyOverridePreference;
 import org.radar.radarlint.settings.SettingsAccessor;
 
 /**
@@ -40,12 +40,14 @@ public class SonarLintCustomizerTab implements ProjectCustomizer.CompositeCatego
         Preferences preferences = ProjectUtils.getPreferences(currentProject, SonarLintPropertiesComponent.class, false);
         
         SettingsAccessor<Boolean> sonarLintActivePreference=new SonarLintActivePreference(preferences);
-        SettingsAccessor<String> excludedFilePatternsPreference=new ExcludedFilePatterns(preferences);
-        
+        SettingsAccessor<String> projectKeyOverridePreference = new ProjectKeyOverridePreference(preferences);
+        SettingsAccessor<String> excludedFilePatternsPreference = new ExcludedFilePatterns(preferences);
+
         category.setOkButtonListener((ActionEvent e) -> {
             if(category.isValid()) {
                 //save current properties
                 sonarLintActivePreference.setValue(component.isSonarLintActive());
+                projectKeyOverridePreference.setValue(component.getProjectKeyOverride());
                 excludedFilePatternsPreference.setValue(component.getExcludedFilePatterns());
                 
                 EditorAnnotator editorAnnotator = EditorAnnotator.getInstance();
@@ -77,6 +79,7 @@ public class SonarLintCustomizerTab implements ProjectCustomizer.CompositeCatego
         });
         /* Load current properties*/
         component.setSonarLintActive(sonarLintActivePreference.getValue());
+        component.setProjectKeyOverride(projectKeyOverridePreference.getValue());
         component.setExcludedFilePatterns(excludedFilePatternsPreference.getValue());
         
         return component;

--- a/src/main/java/org/radar/radarlint/ui/SonarLintPropertiesComponent.form
+++ b/src/main/java/org/radar/radarlint/ui/SonarLintPropertiesComponent.form
@@ -16,15 +16,17 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="activeCheckbox" max="32767" attributes="0"/>
                   <Component id="jScrollPane1" max="32767" attributes="0"/>
-                  <Group type="102" attributes="0">
-                      <Component id="activeCheckbox" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
                   <Component id="jLabel1" pref="442" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="projectKeyOverride" max="32767" attributes="0"/>
+                  </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -35,10 +37,15 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="activeCheckbox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="213" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="projectKeyOverride" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="jLabel1" min="-2" pref="60" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="jScrollPane1" min="-2" pref="178" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -74,5 +81,19 @@
         </Component>
       </SubComponents>
     </Container>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarLintPropertiesComponent.jLabel2.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="projectKeyOverride">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/radar/radarlint/ui/Bundle.properties" key="SonarLintPropertiesComponent.projectKeyOverride.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
   </SubComponents>
 </Form>

--- a/src/main/java/org/radar/radarlint/ui/SonarLintPropertiesComponent.java
+++ b/src/main/java/org/radar/radarlint/ui/SonarLintPropertiesComponent.java
@@ -20,7 +20,15 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
     public void setSonarLintActive(boolean active) {
         activeCheckbox.setSelected(active);
     }
-    
+
+    public String getProjectKeyOverride() {
+        return projectKeyOverride.getText();
+    }
+
+    public void setProjectKeyOverride(String value) {
+        projectKeyOverride.setText(value);
+    }
+
     public String getExcludedFilePatterns() {
         return excludedFilePatternsTextfield.getText();
     }
@@ -42,6 +50,8 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
         jLabel1 = new javax.swing.JLabel();
         jScrollPane1 = new javax.swing.JScrollPane();
         excludedFilePatternsTextfield = new javax.swing.JTextArea();
+        jLabel2 = new javax.swing.JLabel();
+        projectKeyOverride = new javax.swing.JTextField();
 
         org.openide.awt.Mnemonics.setLocalizedText(activeCheckbox, org.openide.util.NbBundle.getMessage(SonarLintPropertiesComponent.class, "SonarLintPropertiesComponent.activeCheckbox.text")); // NOI18N
 
@@ -51,6 +61,10 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
         excludedFilePatternsTextfield.setRows(5);
         jScrollPane1.setViewportView(excludedFilePatternsTextfield);
 
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getMessage(SonarLintPropertiesComponent.class, "SonarLintPropertiesComponent.jLabel2.text")); // NOI18N
+
+        projectKeyOverride.setText(org.openide.util.NbBundle.getMessage(SonarLintPropertiesComponent.class, "SonarLintPropertiesComponent.projectKeyOverride.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -58,11 +72,13 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(activeCheckbox, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(jScrollPane1)
+                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 442, Short.MAX_VALUE)
                     .addGroup(layout.createSequentialGroup()
-                        .addComponent(activeCheckbox)
-                        .addGap(0, 0, Short.MAX_VALUE))
-                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 442, Short.MAX_VALUE))
+                        .addComponent(jLabel2)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(projectKeyOverride)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -70,10 +86,14 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(activeCheckbox)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 213, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel2)
+                    .addComponent(projectKeyOverride, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 60, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 178, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -83,6 +103,8 @@ public class SonarLintPropertiesComponent extends javax.swing.JPanel {
     private javax.swing.JCheckBox activeCheckbox;
     private javax.swing.JTextArea excludedFilePatternsTextfield;
     private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JTextField projectKeyOverride;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/resources/org/radar/radarlint/ui/Bundle.properties
+++ b/src/main/resources/org/radar/radarlint/ui/Bundle.properties
@@ -105,3 +105,5 @@ RuleDetailsAction.noIssueAtLocation=No SonarLint issue at caret position
 RuleDialog.description.text=<html>\r\n  <head>\r\n\r\n  </head>\r\n  <body>\r\n    <p style="margin-top: 0">\r\n      \r\n    </p>\r\n  </body>\r\n</html>\r\n
 SonarQubeOptionsPanel.jLabel2.text=Token:
 SonarQubeOptionsPanel.tokenField.text=
+SonarLintPropertiesComponent.jLabel2.text=Project Key Override:
+SonarLintPropertiesComponent.projectKeyOverride.text=


### PR DESCRIPTION
Can be set per-project in project preferences.

If not set, the project key will still be pulled from the maven model.