### PR TITLE
Update maven-compiler-plugin to source/target of jdk 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The project README says it's built with 11 and there are
definitely features in use from after Java 8, so we need
to update the compiler plugin to match.